### PR TITLE
refactor: migrate components to Svelte 5 runes

### DIFF
--- a/src/components/App.svelte
+++ b/src/components/App.svelte
@@ -5,12 +5,9 @@
 	import Kofi from './Kofi.svelte';
 	import Work from './Work.svelte';
 
-	export let profile: IProfileResp;
+	let { profile }: { profile: IProfileResp } = $props();
 
-	// sourceLink is empty until the profile loads; keep dataLink empty too so it
-	// never becomes a bogus relative URL.
-	$: dataLink = sourceLink ? `${sourceLink}/blob/main/static/data/profile.json` : '';
-	$: ({
+	const {
 		intro = {} as IProfileResp['intro'],
 		projects = [],
 		technologies = [],
@@ -18,7 +15,11 @@
 		educations = [],
 		interests = [],
 		resumeUrl: { sourceLink = '', fullVersionLink = '' } = {}
-	} = profile || {});
+	} = $derived(profile || {});
+
+	// sourceLink is empty until the profile loads; keep dataLink empty too so it
+	// never becomes a bogus relative URL.
+	const dataLink = $derived(sourceLink ? `${sourceLink}/blob/main/static/data/profile.json` : '');
 </script>
 
 <!-- Remove this is you does not want Kofi widget on your site -->
@@ -29,7 +30,7 @@
 <header class="web-only text-center p-4 sm:p-6 bg-green-400 text-white w-screen">
 	<h1 class="text-4xl">Resumette</h1>
 	<h3>
-		<button on:click={() => window.print()} class="underline text-lg">[Print]</button>
+		<button onclick={() => window.print()} class="underline text-lg">[Print]</button>
 	</h3>
 	<p>
 		Printer-friendly standard résumé, any HTML tags with <code>web-only</code> CSS class will be hidden

--- a/src/components/Hideable.svelte
+++ b/src/components/Hideable.svelte
@@ -1,15 +1,30 @@
 <script lang="ts">
-	export let hide = false;
+	import type { Snippet } from 'svelte';
 
-	const toggleHide = () => (hide = !hide);
+	let { hide = false, children }: { hide?: boolean; children?: Snippet } = $props();
+
+	const toggleHide = (event: Event) => {
+		event.stopPropagation();
+		hide = !hide;
+	};
+
+	const handleKeydown = (event: KeyboardEvent) => {
+		if (event.key === 'Enter' || event.key === ' ') {
+			event.preventDefault();
+			toggleHide(event);
+		}
+	};
 </script>
 
-<div class="group relative" class:web-only={hide} class:text-gray-300={hide} role="button">
+<div class="group relative" class:web-only={hide} class:text-gray-300={hide}>
 	<span
-		on:click|stopPropagation={toggleHide}
+		role="button"
+		tabindex="0"
+		onclick={toggleHide}
+		onkeydown={handleKeydown}
 		class="select-none cursor-pointer"
 		class:cursor-copy={hide}
 	>
-		<slot />
+		{@render children?.()}
 	</span>
 </div>

--- a/src/components/Intro.svelte
+++ b/src/components/Intro.svelte
@@ -1,14 +1,27 @@
 <script lang="ts">
-	export let name: string = 'Foo';
-	export let nickname: string = '';
-	export let title: string = '';
-	export let summary: string = '';
-	export let phone: string = '';
-	export let email: string = '';
-	export let github: string = '';
-	export let linkedin: string = '';
-	export let location: string = '';
-	export let website: string = '';
+	let {
+		name = 'Foo',
+		nickname = '',
+		title = '',
+		summary = '',
+		phone = '',
+		email = '',
+		github = '',
+		linkedin = '',
+		location = '',
+		website = ''
+	}: {
+		name?: string;
+		nickname?: string;
+		title?: string;
+		summary?: string;
+		phone?: string;
+		email?: string;
+		github?: string;
+		linkedin?: string;
+		location?: string;
+		website?: string;
+	} = $props();
 </script>
 
 <div class="flex flex-wrap flex-col sm:flex-row print:flex-row text-sm sm:text-base">

--- a/src/components/Kofi.svelte
+++ b/src/components/Kofi.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { onMount } from 'svelte';
 
-	export let name: string;
+	let { name }: { name: string } = $props();
 
 	let kofiReady = false;
 	let mounted = false;
@@ -38,10 +38,10 @@
 	<script
 		type="text/javascript"
 		src="https://storage.ko-fi.com/cdn/scripts/overlay-widget.js"
-		on:load={kofiLoaded}
+		onload={kofiLoaded}
 	></script>
 </svelte:head>
 
 {#if name}
-	<div id="kofiContainer" class="web-only" />
+	<div id="kofiContainer" class="web-only"></div>
 {/if}

--- a/src/components/Work.svelte
+++ b/src/components/Work.svelte
@@ -1,11 +1,19 @@
 <script lang="ts">
 	import Hideable from './Hideable.svelte';
 
-	export let position: string = '';
-	export let company: string = '';
-	export let url: string = '';
-	export let years: string[] = [];
-	export let details: string[] = [];
+	let {
+		position = '',
+		company = '',
+		url = '',
+		years = [],
+		details = []
+	}: {
+		position?: string;
+		company?: string;
+		url?: string;
+		years?: string[];
+		details?: string[];
+	} = $props();
 </script>
 
 <div class="work-experience">

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -1,5 +1,7 @@
 <script>
 	import '../app.css';
+
+	let { children } = $props();
 </script>
 
-<slot />
+{@render children()}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -2,11 +2,11 @@
 	import App from '../components/App.svelte';
 	import type { PageData } from './$types';
 
-	export let data: PageData;
+	let { data }: { data: PageData } = $props();
 
-	$: intro = data.profile.intro;
-	$: pageTitle = intro.title ? `${intro.name} — ${intro.title}` : intro.name;
-	$: description = intro.summary ?? `Résumé of ${intro.name}`;
+	const intro = $derived(data.profile.intro);
+	const pageTitle = $derived(intro.title ? `${intro.name} — ${intro.title}` : intro.name);
+	const description = $derived(intro.summary ?? `Résumé of ${intro.name}`);
 </script>
 
 <svelte:head>


### PR DESCRIPTION
## Summary
- Convert all components off Svelte 4 legacy syntax to runes: `export let` → `$props()`, `$:` → `$derived`, `on:event` → `onevent`, `<slot />` → snippets with `{@render}`
- Fix a11y warnings in `Hideable`: clickable span now has `role="button"`, `tabindex="0"`, and Enter/Space keyboard support

## Test plan
- `pnpm run check` — 0 errors, 0 warnings
- `pnpm run lint` — clean
- `pnpm run build` — succeeds
- `pnpm run test:unit` — 1/1 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)